### PR TITLE
feat(db_bash_backup/db.sh): use absolute path for sourcing config.sh

### DIFF
--- a/db_bash_backup-main/db.sh
+++ b/db_bash_backup-main/db.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ 
 # Import the configuration file
-source config.sh
+source "$SCRIPT_DIR/config.sh"
 
 # Cycle through all the databases and back up each one
 for db_name in "${databases[@]}"; do


### PR DESCRIPTION
If the script is run via an absolute path (or cronjob) it doesn't find the config script. With this modification we use the absolute path (taken automatically)